### PR TITLE
create facts into data/sources

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -15,3 +15,4 @@ async def enable(services):
         plugin_svc = EmuService()
         await plugin_svc.clone_repo()
         await plugin_svc.populate_data_directory()
+        await plugin_svc.populate_sources_directory()


### PR DESCRIPTION
This is a feature addition request to create facts definition yaml files.
The default values of the variable definitions will be collected from the yaml file of the adversary emulation plan and facts definition yml files will be created under the data/sources directory.
The list of variables will now appear in the sources menu of MITRE CALDERA.
By selecting any of the facts in the AUTONOMOUS menu of operations, the variables in the operation command will be replaced by their values.
![FIN6_facts](https://user-images.githubusercontent.com/4151943/105488176-98c8bc80-5cf4-11eb-8760-f3337dae55b3.png)
![APT29_facts](https://user-images.githubusercontent.com/4151943/105488212-a3835180-5cf4-11eb-98f7-44d3086e578f.png)
![APT29_operation](https://user-images.githubusercontent.com/4151943/105488468-ffe67100-5cf4-11eb-9a36-b684911de485.png)
