### PR TITLE
added payload extraction from ability

### DIFF
--- a/app/emu_svc.py
+++ b/app/emu_svc.py
@@ -163,6 +163,10 @@ class EmuService(BaseService):
             if details.get('default'):
                 facts.append(dict(trait=fact, value=details.get('default')))
 
+        for platform in ability.get('platforms', dict()).values():
+            for executor in platform.values():
+                payloads.extend(executor.get('payloads', []))
+
         await self._store_payloads(payloads)
         await self._write_ability(ability)
         return ability['id'], facts


### PR DESCRIPTION
## Description

Added code that extracts what payloads are used for a given ability.

The `save_ability()` function inside `emu_svc.py` used to instantiate `payloads = []` but did not populate the list of needed payloads


## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran `python3 server.py --insecure --fresh`, and made sure that all the needed payloads were found in the `plugins/emu/payloads`

## Checklist:

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
