### PR TITLE
[VIRTS-2216] Move up check for adversary yaml

### DIFF
--- a/app/emu_svc.py
+++ b/app/emu_svc.py
@@ -77,6 +77,9 @@ class EmuService(BaseService):
                     self.log.error(e)
                     errors += 1
 
+        if not details.get('adversary_name'):
+            return 0, 0, 1
+
         await self._save_adversary(id=details.get('id', str(uuid.uuid4())),
                                    name=details.get('adversary_name', filename),
                                    description=details.get('adversary_description', filename),

--- a/app/emu_svc.py
+++ b/app/emu_svc.py
@@ -77,7 +77,7 @@ class EmuService(BaseService):
                     self.log.error(e)
                     errors += 1
 
-        if not details.get('adversary_name'):
+        if 'adversary_name' not in details:
             return 0, 0, 1
 
         await self._save_adversary(id=details.get('id', str(uuid.uuid4())),

--- a/app/emu_svc.py
+++ b/app/emu_svc.py
@@ -66,6 +66,11 @@ class EmuService(BaseService):
                 details = entry['emulation_plan_details']
                 if not self._is_valid_format_version(entry['emulation_plan_details']):
                     return 0, 0, 1
+
+        if 'adversary_name' not in details:
+            return 0, 0, 1
+
+        for entry in emulation_plan:
             if await self._is_ability(entry):
                 at_total += 1
                 try:
@@ -76,9 +81,6 @@ class EmuService(BaseService):
                 except Exception as e:
                     self.log.error(e)
                     errors += 1
-
-        if 'adversary_name' not in details:
-            return 0, 0, 1
 
         await self._save_adversary(id=details.get('id', str(uuid.uuid4())),
                                    name=details.get('adversary_name', filename),


### PR DESCRIPTION
## Description

In app/emu_svc.py, there was the possibility of a blank adversary being created, given that the adversary file was of the incorrect yaml format (missing emulation plan details). _ingest_emulation_plan now checks for improper adversary file format before creating/saving adversaries.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

Created several improperly formatted adversary.yaml files based off of [CTID Adversary YAML Format](https://github.com/center-for-threat-informed-defense/adversary_emulation_library/blob/master/structure/format_dictionary.yaml). Upon enabling the plugin and running CALDERA, I was able to confirm that none of the blank adversaries were created.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
