### PR TITLE
[VIRTS-2215]: Load EMU Payloads

### DIFF
--- a/app/emu_svc.py
+++ b/app/emu_svc.py
@@ -159,6 +159,11 @@ class EmuService(BaseService):
         payloads = []
         facts = []
 
+        for platform in ability.get('platforms', dict()).values():
+            for executor_details in platform.values():
+                if executor_details.get('payloads'):
+                    payloads.extend(executor_details['payloads'])
+
         for fact, details in ab.get('input_arguments', dict()).items():
             if details.get('default'):
                 facts.append(dict(trait=fact, value=details.get('default')))


### PR DESCRIPTION
## Description

This is a bug fix for an issue that prevented adversary payloads from being transferred to the emu/payloads directory. An empty list of payload files was being provided (so nothing was copied); that list is now being populated after parsing the abilities dictionary, and payload files are copied to the /plugins directory.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran/stepped through CALDERA with emu plugin enabled. The payloads can be seen in the /plugins folder now.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
