### PR TITLE
VIRTS2852: Missing payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *__pycache__*
 .idea/*
 conf/secrets.yml
-adversary-emulation-plans/*
+data/adversary-emulation-plans
 data/abilities
 data/adversaries
+data/sources
+payloads

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A plugin supplying CALDERA with TTPs from the Center for Threat Informed Defense Adversary Emulation Plans.
 
-Each emulation plan will have an advesary and a set of facts. Please ensure to select the related facts to the advesary when starting an operation.
+Each emulation plan will have an adversary and a set of facts. Please ensure to select the related facts to the 
+adversary when starting an operation. Some adversaries may require additional payloads and executables to be 
+downloaded. Run the `download_payloads.sh` script to download these binaries to the `payloads` directory. 
 
 ## Acknowledgements
 

--- a/download_payloads.sh
+++ b/download_payloads.sh
@@ -1,0 +1,34 @@
+# We are not able to bundle some payloads because their licensing
+# prohibits redistribution (notably sysinternals).  This script will
+# will download non-redistributable payloads.  If you're deploying
+# the plugin without interent access, you can copy this script to
+# an internet connected host, run it, and then copy the resulting
+# payloads back to the emu/payloads directory
+
+curl -o payloads/AdFind.zip http://www.joeware.net/downloads/files/AdFind.zip
+unzip payloads/AdFind.zip -d payloads/
+
+curl -o payloads/dnscat2.ps1 https://raw.githubusercontent.com/lukebaggett/dnscat2-powershell/master/dnscat2.ps1
+
+curl -o payloads/NetSess.zip http://www.joeware.net/downloads/files/NetSess.zip
+unzip payloads/NetSess.zip -d payloads/
+
+curl -o payloads/nbtscan.exe http://unixwiz.net/tools/nbtscan-1.0.35.exe
+
+curl -o payloads/psexec.exe https://github.com/ropnop/impacket_static_binaries/releases/download/0.9.22.dev-binaries/psexec_windows.exe
+cp payloads/psexec.exe payloads/PsExec.exe
+
+curl -o payloads/putty.exe https://the.earth.li/~sgtatham/putty/latest/w64/putty.exe
+
+curl -o payloads/secretsdump.exe https://github.com/ropnop/impacket_static_binaries/releases/download/0.9.22.dev-binaries/secretsdump_windows.exe
+
+curl -o payloads/tcping.exe https://download.elifulkerson.com//files/tcping/0.39/tcping.exe
+
+curl -o payloads/wce_v1_41beta_universal.zip https://www.ampliasecurity.com/research/wce_v1_41beta_universal.zip
+unzip payloads/wce_v1_41beta_universal.zip -d payloads/
+
+curl -o payloads/wmiexec.vbs https://raw.githubusercontent.com/Twi1ight/AD-Pentest-Script/master/wmiexec.vbs
+
+
+
+

--- a/hook.py
+++ b/hook.py
@@ -27,3 +27,4 @@ async def enable(services):
             shutil.rmtree(full_path)
 
     await plugin_svc.populate_data_directory()
+    # await plugin_svc.decrypt_payloads()

--- a/hook.py
+++ b/hook.py
@@ -27,4 +27,4 @@ async def enable(services):
             shutil.rmtree(full_path)
 
     await plugin_svc.populate_data_directory()
-    # await plugin_svc.decrypt_payloads()
+    await plugin_svc.decrypt_payloads()


### PR DESCRIPTION
## Description

Resolves issues with missing payloads for abilities within the emu plugin. Although some payloads are located within the `adversary-emulation-plans` repository in plaintext, some of the newer plans' payloads have been encrypted with the crypt_executables.py script. The proposed changes calls the crypt_exectables.py script to decrypt the payloads using the provided password from the adversary-emulation-plans documentation. Additionally, some payloads are not located within the repository at all and must be pulled from the source using the `download_payloads.sh` script.

The bugs have been introduced due to the inconsistencies across how plans store payloads within the `adversary-emulation-plans` repository. More changes may need to be made if future plans added to the repository differ in how payloads are stored.

Related issue: https://github.com/mitre/caldera/issues/2251

This PR aims to also resolve some issues with formatting of tactic name during import of the abilities ("Defense Evasion" vs. "defense-evasion") and has added additional directories to the gitignore.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## How Has This Been Tested?

Payload decryption works upon enabling the emu plugin. The download_payloads script has not been tested due to environment restrictions.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
