### PR TITLE
Group filter planner

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,14 @@
+[flake8]
+max-line-length = 180
+exclude =
+    .svn,
+    CVS,
+    .bzr,
+    .hg,
+    .git,
+    __pycache__,
+    .tox,
+    venv,
+    .venv
+    data
+	payloads

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
           - python-version: 3.8
             toxenv: py38,coverage-ci
           - python-version: 3.9
-              toxenv: py39,coverage-ci
+            toxenv: py39,coverage-ci
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,34 @@
+name: Code Testing
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: 3.7
+            toxenv: py37,coverage-ci
+          - python-version: 3.8
+            toxenv: py38,coverage-ci
+          - python-version: 3.9
+              toxenv: py39,coverage-ci
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install --upgrade virtualenv
+          pip install tox
+      - name: Run tests
+        env:
+          TOXENV: ${{ matrix.toxenv }}
+        run: tox

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,11 +10,11 @@ jobs:
       matrix:
         include:
           - python-version: 3.7
-            toxenv: py37,coverage-ci
+            toxenv: py37,style,coverage-ci
           - python-version: 3.8
-            toxenv: py38,coverage-ci
+            toxenv: py38,style,coverage-ci
           - python-version: 3.9
-            toxenv: py39,coverage-ci
+            toxenv: py39,style,coverage-ci
 
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 3.7.7
+      hooks:
+          - id: flake8
+            additional_dependencies: [flake8-bugbear]
+    - repo: https://github.com/PyCQA/bandit
+      rev: 1.6.2
+      hooks:
+        - id: bandit
+          entry: bandit -ll --exclude=tests/ --skip=B322,B303

--- a/app/emu_svc.py
+++ b/app/emu_svc.py
@@ -119,7 +119,7 @@ class EmuService(BaseService):
     def _is_valid_format_version(details):
         try:
             return float(details['format_version']) >= 1.0
-        except:
+        except Exception:
             return False
 
     async def _write_adversary(self, data):
@@ -162,7 +162,7 @@ class EmuService(BaseService):
                 if 'elevation_required' in ex:
                     return 'Elevated'
                 return False
-        except:
+        except Exception:
             return False
 
     async def _save_ability(self, ab):
@@ -207,8 +207,8 @@ class EmuService(BaseService):
             for path in Path(self.repo_dir).rglob(payload):
                 try:
                     shutil.copyfile(path, os.path.join(self.payloads_dir, path.name))
-                except:
-                    print('could not move')
+                except Exception as e:
+                    self.log.error(e)
 
     async def _save_source(self, name, facts):
         source = dict(

--- a/app/group_filtered_planner.py
+++ b/app/group_filtered_planner.py
@@ -1,0 +1,67 @@
+class GroupFilteredPlanner:
+    def __init__(self, operation, planning_svc, stopping_conditions=(), filtered_groups_by_ability=None):
+        self.operation = operation
+        self.planning_svc = planning_svc
+        self.stopping_conditions = stopping_conditions
+        self.stopping_condition_met = False
+        self.state_machine = ['fetch_and_run_links']
+        self.next_bucket = 'fetch_and_run_links'   # repeat this bucket until we run out of links.
+        self.filtered_groups_by_ability = filtered_groups_by_ability if filtered_groups_by_ability else dict()
+        self.pending_links = []
+        self.current_ability_index = 0
+
+    async def execute(self):
+        await self.planning_svc.execute_planner(self)
+
+    async def fetch_and_run_links(self):
+        links_to_use = await self._fetch_links()
+        if links_to_use:
+            # Each agent will run the next available step.
+            await self.operation.wait_for_links_completion(links_to_use)
+        else:
+            self.next_bucket = None
+
+    async def _fetch_links(self):
+        # If we have no pending links, go to the next ability in the adversary profile.
+        # Determine which agents can run the ability based on filtered_groups_by_activity and then generate
+        # the pool of links for just that ability.
+        # If the ability does not generate any runnable links, iterate through the
+        # atomic ordering until we find an ability that does generate links.
+        while not self.pending_links:
+            if self.current_ability_index >= len(self.operation.adversary.atomic_ordering):
+                return []
+            ability_id = self.operation.adversary.atomic_ordering[self.current_ability_index]
+            self.pending_links = await self._get_pending_links(ability_id)
+            self.current_ability_index += 1
+        return self._fetch_from_pending_links()
+
+    async def _get_pending_links(self, ability_id):
+        valid_agents = self._get_valid_agents_for_ability(ability_id)
+        potential_links = []
+        for agent in valid_agents:
+            potential_links += await self._get_links(agent=agent)
+        return [link for link in potential_links if link.ability.ability_id == ability_id]
+
+    def _fetch_from_pending_links(self):
+        """Return at most one link per agent. Any link that gets assigned will be removed from self.pending_links."""
+        assigned_agent_paws = set()
+        links_to_use = []
+        unassigned_links = []
+        for link in self.pending_links:
+            if link.paw not in assigned_agent_paws:
+                assigned_agent_paws.add(link.paw)
+                links_to_use.append(link)
+            else:
+                # Agent has already been assigned a link from this pool
+                unassigned_links.append(link)
+        self.pending_links = unassigned_links
+        return links_to_use
+
+    def _get_valid_agents_for_ability(self, ability_id):
+        if ability_id not in self.filtered_groups_by_ability:
+            return self.operation.agents
+        valid_agents = []
+        for agent in self.operation.agents:
+            if agent.group in self.filtered_groups_by_ability.get(ability_id, []):
+                valid_agents.append(agent)
+        return valid_agents

--- a/app/group_filtered_planner.py
+++ b/app/group_filtered_planner.py
@@ -65,3 +65,6 @@ class LogicalPlanner:
             if agent.group in self.filtered_groups_by_ability.get(ability_id, []):
                 valid_agents.append(agent)
         return valid_agents
+
+    async def _get_links(self, agent=None):
+        return await self.planning_svc.get_links(operation=self.operation, agent=agent)

--- a/app/group_filtered_planner.py
+++ b/app/group_filtered_planner.py
@@ -1,4 +1,4 @@
-class GroupFilteredPlanner:
+class LogicalPlanner:
     def __init__(self, operation, planning_svc, stopping_conditions=(), filtered_groups_by_ability=None):
         self.operation = operation
         self.planning_svc = planning_svc

--- a/tests/test_group_filtered_planner.py
+++ b/tests/test_group_filtered_planner.py
@@ -258,7 +258,6 @@ class TestGroupFilteredPlanner:
         assert links[1].ability.ability_id == '1011'
         assert links[1].command == 'test command'
 
-
     async def test_fetch_links_with_filter(self, filtered_planner):
         assert not filtered_planner.pending_links
         assert filtered_planner.current_ability_index == 0

--- a/tests/test_group_filtered_planner.py
+++ b/tests/test_group_filtered_planner.py
@@ -60,6 +60,7 @@ def potential_links_dict():
             Link('test command', 'paw1', DummyAbility('123'), None),
             Link('test command variant', 'paw1', DummyAbility('123'), None),
             Link('test command', 'paw1', DummyAbility('456'), None),
+            Link('test command', 'paw1', DummyAbility('1011'), None),
         ],
         'paw2': [
             Link('test command', 'paw2', DummyAbility('123'), None),
@@ -82,6 +83,7 @@ def potential_links_list():
         Link('test command', 'paw2', DummyAbility('123'), None),
         Link('test command', 'paw3', DummyAbility('1011'), None),
         Link('test command', 'paw4', DummyAbility('456'), None),
+        Link('test command', 'paw1', DummyAbility('1011'), None),
     ]
 
 
@@ -202,10 +204,13 @@ class TestGroupFilteredPlanner:
         links_to_use = await planner_without_filter._fetch_links()
         assert len(planner_without_filter.pending_links) == 0
         assert planner_without_filter.current_ability_index == 4
-        assert len(links_to_use) == 1
-        assert links_to_use[0].paw == 'paw3'
+        assert len(links_to_use) == 2
+        assert links_to_use[0].paw == 'paw1'
         assert links_to_use[0].command == 'test command'
         assert links_to_use[0].ability.ability_id == '1011'
+        assert links_to_use[1].paw == 'paw3'
+        assert links_to_use[1].command == 'test command'
+        assert links_to_use[1].ability.ability_id == '1011'
 
         # fifth pass - end
         links_to_use = await planner_without_filter._fetch_links()
@@ -245,10 +250,14 @@ class TestGroupFilteredPlanner:
         assert links[1].command == 'test command'
 
         links = await filtered_planner._get_pending_links('1011')
-        assert len(links) == 1
-        assert links[0].paw == 'paw3'
+        assert len(links) == 2
+        assert links[0].paw == 'paw1'
         assert links[0].ability.ability_id == '1011'
         assert links[0].command == 'test command'
+        assert links[1].paw == 'paw3'
+        assert links[1].ability.ability_id == '1011'
+        assert links[1].command == 'test command'
+
 
     async def test_fetch_links_with_filter(self, filtered_planner):
         assert not filtered_planner.pending_links
@@ -291,10 +300,13 @@ class TestGroupFilteredPlanner:
         links_to_use = await filtered_planner._fetch_links()
         assert len(filtered_planner.pending_links) == 0
         assert filtered_planner.current_ability_index == 4
-        assert len(links_to_use) == 1
-        assert links_to_use[0].paw == 'paw3'
+        assert len(links_to_use) == 2
+        assert links_to_use[0].paw == 'paw1'
         assert links_to_use[0].command == 'test command'
         assert links_to_use[0].ability.ability_id == '1011'
+        assert links_to_use[1].paw == 'paw3'
+        assert links_to_use[1].command == 'test command'
+        assert links_to_use[1].ability.ability_id == '1011'
 
         # fifth pass - end
         links_to_use = await filtered_planner._fetch_links()

--- a/tests/test_group_filtered_planner.py
+++ b/tests/test_group_filtered_planner.py
@@ -1,7 +1,7 @@
 import pytest
 
 from app.objects.secondclass.c_link import Link
-from plugins.emu.app.group_filtered_planner import GroupFilteredPlanner
+from plugins.emu.app.group_filtered_planner import LogicalPlanner
 
 
 BUCKET_NAME = 'fetch_and_run_links'
@@ -14,6 +14,9 @@ class DummyOperation:
 
     async def wait_for_links_completion(self, _):
         return
+
+    async def apply(self, link):
+        return link
 
 
 class DummyAdversary:
@@ -108,7 +111,7 @@ def generate_planner(potential_links_dict):
 
     def _generate_planner(atomic_ordering, agents, filtered_groups_by_ability=None):
         operation = DummyOperation(DummyAdversary(atomic_ordering), agents)
-        planner = GroupFilteredPlanner(operation, None, filtered_groups_by_ability=filtered_groups_by_ability)
+        planner = LogicalPlanner(operation, None, filtered_groups_by_ability=filtered_groups_by_ability)
         planner._get_links = _get_links_mock
         return planner
     return _generate_planner

--- a/tests/test_group_filtered_planner.py
+++ b/tests/test_group_filtered_planner.py
@@ -1,0 +1,303 @@
+import pytest
+
+from app.objects.secondclass.c_link import Link
+from plugins.emu.app.group_filtered_planner import GroupFilteredPlanner
+
+
+BUCKET_NAME = 'fetch_and_run_links'
+
+
+class DummyOperation:
+    def __init__(self, dummy_adversary, dummy_agents):
+        self.adversary = dummy_adversary
+        self.agents = dummy_agents
+
+    async def wait_for_links_completion(self, _):
+        return
+
+
+class DummyAdversary:
+    def __init__(self, atomic_ordering):
+        self.atomic_ordering = atomic_ordering
+
+
+class DummyAgent:
+    def __init__(self, paw, group):
+        self.paw = paw
+        self.group = group
+
+
+class DummyAbility:
+    def __init__(self, ability_id):
+        self.ability_id = ability_id
+
+
+@pytest.fixture
+def dummy_agents():
+    return [
+        DummyAgent('paw1', 'group1'),
+        DummyAgent('paw2', 'group2'),
+        DummyAgent('paw3', 'group3'),
+        DummyAgent('paw4', 'group1'),
+        DummyAgent('paw5', 'group4'),
+    ]
+
+
+@pytest.fixture
+def pending_links():
+    return [
+        Link('test command', 'paw1', DummyAbility('123'), None),
+        Link('test command variant', 'paw1', DummyAbility('123'), None),
+        Link('test command', 'paw2', DummyAbility('123'), None),
+        Link('test command', 'paw3', DummyAbility('123'), None),
+    ]
+
+
+@pytest.fixture
+def potential_links_dict():
+    return {
+        'paw1': [
+            Link('test command', 'paw1', DummyAbility('123'), None),
+            Link('test command variant', 'paw1', DummyAbility('123'), None),
+            Link('test command', 'paw1', DummyAbility('456'), None),
+        ],
+        'paw2': [
+            Link('test command', 'paw2', DummyAbility('123'), None),
+        ],
+        'paw3': [
+            Link('test command', 'paw3', DummyAbility('1011'), None),
+        ],
+        'paw4': [
+           Link('test command', 'paw4', DummyAbility('456'), None),
+        ],
+    }
+
+
+@pytest.fixture
+def potential_links_list():
+    return [
+        Link('test command', 'paw1', DummyAbility('123'), None),
+        Link('test command variant', 'paw1', DummyAbility('123'), None),
+        Link('test command', 'paw1', DummyAbility('456'), None),
+        Link('test command', 'paw2', DummyAbility('123'), None),
+        Link('test command', 'paw3', DummyAbility('1011'), None),
+        Link('test command', 'paw4', DummyAbility('456'), None),
+    ]
+
+
+@pytest.fixture
+def sample_abilities():
+    return ['123', '456', '789', '1011']
+
+
+@pytest.fixture
+def sample_filter():
+    return {
+        '123': ['group1'],
+        '789': ['group2'],
+        '1011': ['group1', 'group3'],
+    }
+
+
+@pytest.fixture
+def generate_planner(potential_links_dict):
+    async def _get_links_mock(agent):
+        return potential_links_dict.get(agent.paw, [])
+
+    def _generate_planner(atomic_ordering, agents, filtered_groups_by_ability=None):
+        operation = DummyOperation(DummyAdversary(atomic_ordering), agents)
+        planner = GroupFilteredPlanner(operation, None, filtered_groups_by_ability=filtered_groups_by_ability)
+        planner._get_links = _get_links_mock
+        return planner
+    return _generate_planner
+
+
+@pytest.fixture
+def planner_without_filter(generate_planner, dummy_agents, sample_abilities):
+    return generate_planner(sample_abilities, dummy_agents)
+
+
+@pytest.fixture
+def filtered_planner(generate_planner, dummy_agents, sample_abilities, sample_filter):
+    return generate_planner(sample_abilities, dummy_agents, filtered_groups_by_ability=sample_filter)
+
+
+class TestGroupFilteredPlanner:
+    async def test_fetch_from_pending_links(self, planner_without_filter, pending_links):
+        planner_without_filter.pending_links = pending_links
+        links_to_use = planner_without_filter._fetch_from_pending_links()
+        assert len(links_to_use) == 3
+        assert len(planner_without_filter.pending_links) == 1
+        assert links_to_use[0].paw == 'paw1' and links_to_use[0].ability.ability_id == '123'
+        assert links_to_use[0].command == 'test command'
+        assert links_to_use[1].paw == 'paw2'
+        assert links_to_use[2].paw == 'paw3'
+        assert planner_without_filter.pending_links[0].paw == 'paw1'
+        assert planner_without_filter.pending_links[0].command == 'test command variant'
+
+    async def test_fetch_from_empty_pending_links(self, planner_without_filter):
+        links_to_use = planner_without_filter._fetch_from_pending_links()
+        assert not links_to_use
+        assert not planner_without_filter.pending_links
+
+    async def test_get_valid_agents_for_abil_without_filter(self, planner_without_filter):
+        assert len(planner_without_filter.operation.agents) == 5
+        valid_agents = planner_without_filter._get_valid_agents_for_ability('123')
+        assert len(valid_agents) == 5
+
+    async def test_get_pending_links_without_filter(self, planner_without_filter):
+        links = await planner_without_filter._get_pending_links('123')
+        assert len(links) == 3
+        assert links[0].paw == 'paw1'
+        assert links[0].ability.ability_id == '123'
+        assert links[0].command == 'test command'
+        assert links[1].paw == 'paw1'
+        assert links[1].ability.ability_id == '123'
+        assert links[1].command == 'test command variant'
+        assert links[2].paw == 'paw2'
+        assert links[2].ability.ability_id == '123'
+        assert links[2].command == 'test command'
+
+    async def test_fetch_links_without_filter(self, planner_without_filter):
+        assert not planner_without_filter.pending_links
+        assert planner_without_filter.current_ability_index == 0
+
+        # first pass
+        links_to_use = await planner_without_filter._fetch_links()
+        assert len(planner_without_filter.pending_links) == 1
+        assert planner_without_filter.pending_links[0].paw == 'paw1'
+        assert planner_without_filter.pending_links[0].command == 'test command variant'
+        assert planner_without_filter.pending_links[0].ability.ability_id == '123'
+        assert planner_without_filter.current_ability_index == 1
+        assert len(links_to_use) == 2
+        assert links_to_use[0].paw == 'paw1'
+        assert links_to_use[0].command == 'test command'
+        assert links_to_use[0].ability.ability_id == '123'
+        assert links_to_use[1].paw == 'paw2'
+        assert links_to_use[1].command == 'test command'
+        assert links_to_use[1].ability.ability_id == '123'
+
+        # second pass - finishes links from first pass
+        links_to_use = await planner_without_filter._fetch_links()
+        assert len(planner_without_filter.pending_links) == 0
+        assert planner_without_filter.current_ability_index == 1
+        assert len(links_to_use) == 1
+        assert links_to_use[0].paw == 'paw1'
+        assert links_to_use[0].command == 'test command variant'
+        assert links_to_use[0].ability.ability_id == '123'
+
+        # third pass - ability #2
+        links_to_use = await planner_without_filter._fetch_links()
+        assert len(planner_without_filter.pending_links) == 0
+        assert planner_without_filter.current_ability_index == 2
+        assert len(links_to_use) == 2
+        assert links_to_use[0].paw == 'paw1'
+        assert links_to_use[0].command == 'test command'
+        assert links_to_use[0].ability.ability_id == '456'
+        assert links_to_use[1].paw == 'paw4'
+        assert links_to_use[1].command == 'test command'
+        assert links_to_use[1].ability.ability_id == '456'
+
+        # fourth pass - skip ability #3 and go to #4
+        links_to_use = await planner_without_filter._fetch_links()
+        assert len(planner_without_filter.pending_links) == 0
+        assert planner_without_filter.current_ability_index == 4
+        assert len(links_to_use) == 1
+        assert links_to_use[0].paw == 'paw3'
+        assert links_to_use[0].command == 'test command'
+        assert links_to_use[0].ability.ability_id == '1011'
+
+        # fifth pass - end
+        links_to_use = await planner_without_filter._fetch_links()
+        assert len(planner_without_filter.pending_links) == 0
+        assert planner_without_filter.current_ability_index == 4
+        assert len(links_to_use) == 0
+
+    async def test_get_valid_agents_for_abil_with_filter(self, filtered_planner):
+        assert len(filtered_planner.operation.agents) == 5
+        valid_agent_paws = [agent.paw for agent in filtered_planner._get_valid_agents_for_ability('123')]
+        assert len(valid_agent_paws) == 2
+        assert 'paw1' in valid_agent_paws
+        assert 'paw4' in valid_agent_paws
+        valid_agent_paws = [agent.paw for agent in filtered_planner._get_valid_agents_for_ability('456')]
+        assert len(valid_agent_paws) == 5
+        valid_agent_paws = [agent.paw for agent in filtered_planner._get_valid_agents_for_ability('789')]
+        assert len(valid_agent_paws) == 1
+        assert 'paw2' in valid_agent_paws
+
+    async def test_get_pending_links_with_filter(self, filtered_planner):
+        links = await filtered_planner._get_pending_links('123')
+        assert len(links) == 2
+        assert links[0].paw == 'paw1'
+        assert links[0].ability.ability_id == '123'
+        assert links[0].command == 'test command'
+        assert links[1].paw == 'paw1'
+        assert links[1].ability.ability_id == '123'
+        assert links[1].command == 'test command variant'
+
+        links = await filtered_planner._get_pending_links('456')
+        assert len(links) == 2
+        assert links[0].paw == 'paw1'
+        assert links[0].ability.ability_id == '456'
+        assert links[0].command == 'test command'
+        assert links[1].paw == 'paw4'
+        assert links[1].ability.ability_id == '456'
+        assert links[1].command == 'test command'
+
+        links = await filtered_planner._get_pending_links('1011')
+        assert len(links) == 1
+        assert links[0].paw == 'paw3'
+        assert links[0].ability.ability_id == '1011'
+        assert links[0].command == 'test command'
+
+    async def test_fetch_links_with_filter(self, filtered_planner):
+        assert not filtered_planner.pending_links
+        assert filtered_planner.current_ability_index == 0
+
+        # first pass
+        links_to_use = await filtered_planner._fetch_links()
+        assert len(filtered_planner.pending_links) == 1
+        assert filtered_planner.pending_links[0].paw == 'paw1'
+        assert filtered_planner.pending_links[0].command == 'test command variant'
+        assert filtered_planner.pending_links[0].ability.ability_id == '123'
+        assert filtered_planner.current_ability_index == 1
+        assert len(links_to_use) == 1
+        assert links_to_use[0].paw == 'paw1'
+        assert links_to_use[0].command == 'test command'
+        assert links_to_use[0].ability.ability_id == '123'
+
+        # second pass - finishes links from first pass
+        links_to_use = await filtered_planner._fetch_links()
+        assert len(filtered_planner.pending_links) == 0
+        assert filtered_planner.current_ability_index == 1
+        assert len(links_to_use) == 1
+        assert links_to_use[0].paw == 'paw1'
+        assert links_to_use[0].command == 'test command variant'
+        assert links_to_use[0].ability.ability_id == '123'
+
+        # third pass - ability #2
+        links_to_use = await filtered_planner._fetch_links()
+        assert len(filtered_planner.pending_links) == 0
+        assert filtered_planner.current_ability_index == 2
+        assert len(links_to_use) == 2
+        assert links_to_use[0].paw == 'paw1'
+        assert links_to_use[0].command == 'test command'
+        assert links_to_use[0].ability.ability_id == '456'
+        assert links_to_use[1].paw == 'paw4'
+        assert links_to_use[1].command == 'test command'
+        assert links_to_use[1].ability.ability_id == '456'
+
+        # fourth pass - skip ability #3 and go to #4
+        links_to_use = await filtered_planner._fetch_links()
+        assert len(filtered_planner.pending_links) == 0
+        assert filtered_planner.current_ability_index == 4
+        assert len(links_to_use) == 1
+        assert links_to_use[0].paw == 'paw3'
+        assert links_to_use[0].command == 'test command'
+        assert links_to_use[0].ability.ability_id == '1011'
+
+        # fifth pass - end
+        links_to_use = await filtered_planner._fetch_links()
+        assert len(filtered_planner.pending_links) == 0
+        assert filtered_planner.current_ability_index == 4
+        assert len(links_to_use) == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,85 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+skipsdist = True
+envlist =
+    py{37,38,39}
+    style
+    coverage
+    bandit
+skip_missing_interpreters = true
+
+[testenv]
+description = run tests
+passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
+deps =
+    virtualenv!=20.0.22
+    pre-commit
+    pytest
+    pytest-aiohttp
+    coverage
+    codecov
+changedir = {homedir}/tmp
+commands =
+	/usr/bin/git clone https://github.com/mitre/caldera.git --recursive {homedir}/tmp
+	/bin/rm -rf {homedir}/tmp/plugins/emu
+	python -m pip install -r {homedir}/tmp/requirements.txt
+	/usr/bin/cp -R {toxinidir} {homedir}/tmp/plugins/emu
+    coverage run -p -m pytest --tb=short --rootdir={homedir}/tmp -Werror plugins/emu/tests
+allowlist_externals =
+	/usr/bin/sudo *
+	/usr/bin/git *
+	/usr/bin/cp *
+
+[testenv:py38]
+description = run tests
+passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
+deps =
+    virtualenv!=20.0.22
+    pre-commit
+    pytest
+    pytest-aiohttp
+    coverage
+    codecov
+changedir = {homedir}/tmp
+commands =
+	/usr/bin/git clone https://github.com/mitre/caldera.git --recursive {homedir}/tmp
+	/bin/rm -rf {homedir}/tmp/plugins/emu
+	python -m pip install -r {homedir}/tmp/requirements.txt
+	/usr/bin/cp -R {toxinidir} {homedir}/tmp/plugins/emu
+    coverage run -p -m pytest --tb=short --rootdir={homedir}/tmp {homedir}/tmp/plugins/emu/tests
+allowlist_externals =
+	/usr/bin/sudo *
+	/usr/bin/git *
+	/usr/bin/cp *
+
+[testenv:style]
+deps = pre-commit
+skip_install = true
+changedir={toxinidir}
+commands =
+    pre-commit run --all-files --show-diff-on-failure
+
+[testenv:coverage]
+deps =
+    coverage
+skip_install = true
+changedir = {homedir}/tmp
+commands =
+    coverage combine
+    coverage html
+    coverage report
+
+[testenv:coverage-ci]
+deps =
+    coveralls
+    coverage
+skip_install = true
+changedir = {homedir}/tmp
+commands =
+    coverage combine
+    coverage xml
+    coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -28,28 +28,6 @@ commands =
 	/bin/rm -rf {homedir}/tmp/plugins/emu
 	python -m pip install -r {homedir}/tmp/requirements.txt
 	/usr/bin/cp -R {toxinidir} {homedir}/tmp/plugins/emu
-    coverage run -p -m pytest --tb=short --rootdir={homedir}/tmp -Werror plugins/emu/tests -W ignore::DeprecationWarning
-allowlist_externals =
-	/usr/bin/sudo *
-	/usr/bin/git *
-	/usr/bin/cp *
-
-[testenv:py38]
-description = run tests
-passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
-deps =
-    virtualenv!=20.0.22
-    pre-commit
-    pytest
-    pytest-aiohttp
-    coverage
-    codecov
-changedir = {homedir}/tmp
-commands =
-	/usr/bin/git clone https://github.com/mitre/caldera.git --recursive {homedir}/tmp
-	/bin/rm -rf {homedir}/tmp/plugins/emu
-	python -m pip install -r {homedir}/tmp/requirements.txt
-	/usr/bin/cp -R {toxinidir} {homedir}/tmp/plugins/emu
     coverage run -p -m pytest --tb=short --rootdir={homedir}/tmp {homedir}/tmp/plugins/emu/tests -W ignore::DeprecationWarning
 allowlist_externals =
 	/usr/bin/sudo *

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands =
 	/bin/rm -rf {homedir}/tmp/plugins/emu
 	python -m pip install -r {homedir}/tmp/requirements.txt
 	/usr/bin/cp -R {toxinidir} {homedir}/tmp/plugins/emu
-    coverage run -p -m pytest --tb=short --rootdir={homedir}/tmp -Werror plugins/emu/tests
+    coverage run -p -m pytest --tb=short --rootdir={homedir}/tmp -Werror plugins/emu/tests -W ignore::DeprecationWarning
 allowlist_externals =
 	/usr/bin/sudo *
 	/usr/bin/git *
@@ -50,7 +50,7 @@ commands =
 	/bin/rm -rf {homedir}/tmp/plugins/emu
 	python -m pip install -r {homedir}/tmp/requirements.txt
 	/usr/bin/cp -R {toxinidir} {homedir}/tmp/plugins/emu
-    coverage run -p -m pytest --tb=short --rootdir={homedir}/tmp {homedir}/tmp/plugins/emu/tests
+    coverage run -p -m pytest --tb=short --rootdir={homedir}/tmp {homedir}/tmp/plugins/emu/tests -W ignore::DeprecationWarning
 allowlist_externals =
 	/usr/bin/sudo *
 	/usr/bin/git *


### PR DESCRIPTION
## Description
New planner that will filter abilities by group, meaning that users can set abilities to only apply to certain agents. This is useful for sequential execution of adversary emulation plans where agent 1 runs commands on host 1 before agent 2 runs different commands on host 2, rather than having both agents run the same commands on both hosts simultaneously.
Also includes the associated pytests and github workflow for running the tests.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Created and ran associated pytests. Also created the below test planner to use with the Check adversary and two agents in two different groups (`group1` and `group2`), and verified that the planner assigned the appropriate links at the appropriate time.

```yaml
---

id: 2ac1fd58-16be-4815-997c-f74d3e1508a4
name: Test Group Filtered Planner
description: |
  Group filter planner
module: plugins.emu.app.group_filtered_planner
params:
  filtered_groups_by_ability:
    bd527b63-9f9e-46e0-9816-b8434d2b8989:
      - group1
    6e1a53c0-7352-4899-be35-fa7f364d5722:
      - group1
    52177cc1-b9ab-4411-ac21-2eadc4b5d3b8:
      - group2
    335cea7b-bec0-48c6-adfb-6066070f5f68:
      - group2
    e8017c46-acb8-400c-a4b5-b3362b5b5baa:
      - group1
    9849d956-37ea-49f2-a8b5-f2ca080b315d:
      - group1
    830bb6ed-9594-4817-b1a1-c298c0f9f425:
      - group1
      - group2
    b18e8767-b7ea-41a3-8e80-baf65a5ddef5:
      - group2
ignore_enforcement_modules: []
allow_repeatable_abilities: False

```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
