### PR TITLE
Planner transfer

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -21,7 +21,7 @@ async def enable(services):
     if not os.path.isdir(plugin_svc.repo_dir):
         await plugin_svc.clone_repo()
 
-    for directory in ["abilities", "adversaries", "sources"]:
+    for directory in ['abilities', 'adversaries', 'sources', 'planners']:
         full_path = os.path.join(data_dir, directory)
         if os.path.isdir(full_path):
             shutil.rmtree(full_path)

--- a/tests/test_emu_svc.py
+++ b/tests/test_emu_svc.py
@@ -2,7 +2,6 @@ import glob
 import yaml
 import shutil
 
-import asyncio
 import pytest
 
 from unittest.mock import patch

--- a/tests/test_emu_svc.py
+++ b/tests/test_emu_svc.py
@@ -1,0 +1,92 @@
+import glob
+import yaml
+import shutil
+
+import asyncio
+import pytest
+
+from unittest.mock import patch
+
+from app.utility.base_world import BaseWorld
+from plugins.emu.app.emu_svc import EmuService
+
+
+@pytest.fixture
+def emu_svc():
+    return EmuService()
+
+
+@pytest.fixture
+def planner_yaml():
+    return [yaml.safe_load('''
+---
+id: testid
+name: Test Planner
+description: |
+  Test planner
+module: plugins.emu.app.test_planner_module
+params:
+  param_name:
+    key1:
+      - value1
+    key2:
+      - value2
+ignore_enforcement_modules: []
+allow_repeatable_abilities: False
+''')]
+
+
+@pytest.fixture
+def not_planner_yaml():
+    return [yaml.safe_load('''
+---
+name: I am a yaml file
+value: But I am not a planner
+description: something
+''')]
+
+
+class TestEmuSvc:
+    LIBRARY_GLOB_PATH = 'plugins/emu/data/adversary-emulation-plans/*'
+    PLANNER_GLOB_PATH = 'plugins/emu/data/adversary-emulation-plans/*/Emulation_Plan/yaml/planners/*.yml'
+    PLANNER_PATH = 'plugins/emu/data/adversary-emulation-plans/library1/Emulation_Plan/yaml/planners/test_planner.yml'
+    DEST_PLANNER_PATH = 'plugins/emu/data/planners/testid.yml'
+
+    def test_general_svc_creation(self, emu_svc):
+        assert emu_svc.emu_dir == 'plugins/emu'
+        assert emu_svc.repo_dir == 'plugins/emu/data/adversary-emulation-plans'
+        assert emu_svc.data_dir == 'plugins/emu/data'
+        assert emu_svc.payloads_dir == 'plugins/emu/payloads'
+
+    async def test_ingest_planner(self, emu_svc, planner_yaml):
+
+        with patch.object(BaseWorld, 'strip_yml', return_value=planner_yaml) as new_strip_yml:
+            with patch.object(shutil, 'copyfile', return_value=None) as new_copyfile:
+                await emu_svc._ingest_planner(TestEmuSvc.PLANNER_PATH)
+        new_strip_yml.assert_called_once_with(TestEmuSvc.PLANNER_PATH)
+        new_copyfile.assert_called_once_with(TestEmuSvc.PLANNER_PATH, TestEmuSvc.DEST_PLANNER_PATH)
+
+    async def test_ingest_bad_planner(self, emu_svc, not_planner_yaml):
+        with patch.object(BaseWorld, 'strip_yml', return_value=not_planner_yaml) as new_strip_yml:
+            with patch.object(shutil, 'copyfile', return_value=None) as new_copyfile:
+                await emu_svc._ingest_planner(TestEmuSvc.PLANNER_PATH)
+        new_strip_yml.assert_called_once_with(TestEmuSvc.PLANNER_PATH)
+        new_copyfile.assert_not_called()
+
+    async def test_load_planners(self, emu_svc, planner_yaml):
+        with patch.object(BaseWorld, 'strip_yml', return_value=planner_yaml) as new_strip_yml:
+            with patch.object(shutil, 'copyfile', return_value=None) as new_copyfile:
+                with patch.object(glob, 'iglob', return_value=[TestEmuSvc.PLANNER_PATH]) as new_iglob:
+                    await emu_svc._load_planners(TestEmuSvc.LIBRARY_GLOB_PATH)
+        new_iglob.assert_called_once_with(TestEmuSvc.PLANNER_GLOB_PATH)
+        new_strip_yml.assert_called_once_with(TestEmuSvc.PLANNER_PATH)
+        new_copyfile.assert_called_once_with(TestEmuSvc.PLANNER_PATH, TestEmuSvc.DEST_PLANNER_PATH)
+
+    async def test_load_bad_planners(self, emu_svc, not_planner_yaml):
+        with patch.object(BaseWorld, 'strip_yml', return_value=not_planner_yaml) as new_strip_yml:
+            with patch.object(shutil, 'copyfile', return_value=None) as new_copyfile:
+                with patch.object(glob, 'iglob', return_value=[TestEmuSvc.PLANNER_PATH]) as new_iglob:
+                    await emu_svc._load_planners(TestEmuSvc.LIBRARY_GLOB_PATH)
+        new_iglob.assert_called_once_with(TestEmuSvc.PLANNER_GLOB_PATH)
+        new_strip_yml.assert_called_once_with(TestEmuSvc.PLANNER_PATH)
+        new_copyfile.assert_not_called()


### PR DESCRIPTION
## Description
Provides the capability to ingest custom CALDERA planners from the adversary emulation repos. Refactors some of the existing code to make it cleaner and remove repetition.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Provided unit tests, and also ran the emu plugin with test planner files within some of the adv emu repos and confirmed that they were copied and loaded into CALDERA.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
