### PR TITLE
Adding sandworm psexec.py to payload download script

### DIFF
--- a/download_payloads.sh
+++ b/download_payloads.sh
@@ -31,6 +31,4 @@ unzip payloads/wce_v1_41beta_universal.zip -d payloads/
 
 curl -o payloads/wmiexec.vbs https://raw.githubusercontent.com/Twi1ight/AD-Pentest-Script/master/wmiexec.vbs
 
-
-
-
+curl -o payloads/psexec_sandworm.py https://raw.githubusercontent.com/SecureAuthCorp/impacket/c328de825265df12ced44d14b36c688cd9973f5c/examples/psexec.py


### PR DESCRIPTION
## Description
Update the download-payloads script to pull down the specific version of psexec.py that was used in evals, so that environments without that script pre-installed can still run the associated abilities.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Ran the script and confirmed that the payload was downloaded in the `payloads` directory.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
