### PR TITLE
Resolve depdency issue with bandit pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
     - repo: https://gitlab.com/pycqa/flake8
-      rev: 3.7.7
+      rev: 5.0.4
       hooks:
           - id: flake8
             additional_dependencies: [flake8-bugbear]
     - repo: https://github.com/PyCQA/bandit
-      rev: 1.6.2
+      rev: 1.7.4
       hooks:
         - id: bandit
           entry: bandit -ll --exclude=tests/ --skip=B322,B303

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,4 @@ repos:
       rev: 1.7.4
       hooks:
         - id: bandit
-          entry: bandit -ll --exclude=tests/ --skip=B322,B303
+          entry: bandit -ll --exclude=tests/ --skip=B303

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,5 @@ repos:
       hooks:
         - id: bandit
           entry: bandit -ll --exclude=tests/ --skip=B303
+          additional_dependencies:
+            - importlib-metadata<5; python_version < '3.8'

--- a/tox.ini
+++ b/tox.ini
@@ -38,8 +38,7 @@ allowlist_externals =
 [testenv:style]
 deps =
     pre-commit
-    py37: importlib_metadata==4.13.0
-skip_install = true
+    importlib_metadata==4.13.0; python_version == '3.7'
 changedir={toxinidir}
 commands =
     pre-commit run --all-files --show-diff-on-failure

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ allowlist_externals =
 [testenv:style]
 deps =
     pre-commit
-    importlib_metadata==4.13.0; python_version == '3.7'
+    importlib-metadata==4.8.1; python_version == '3.7'
 changedir={toxinidir}
 commands =
     pre-commit run --all-files --show-diff-on-failure

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ deps =
     pytest-aiohttp
     coverage
     codecov
-    importlib-metadata < 5; python_version < "3.8"  # fix for https://github.com/PyCQA/bandit/issues/951
 changedir = {homedir}/tmp
 commands =
     /usr/bin/git clone https://github.com/mitre/caldera.git --recursive {homedir}/tmp
@@ -39,8 +38,8 @@ allowlist_externals =
 [testenv:style]
 deps =
     pre-commit
-    importlib-metadata < 5; python_version < "3.8"  # fix for https://github.com/PyCQA/bandit/issues/951
-changedir={toxinidir}
+skip_install = true
+changedir = {toxinidir}
 commands =
     pre-commit run --all-files --show-diff-on-failure
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,6 @@ deps =
     importlib-metadata < 5; python_version < "3.8"  # fix for https://github.com/PyCQA/bandit/issues/951
 changedir={toxinidir}
 commands =
-    python -m pip freeze
     pre-commit run --all-files --show-diff-on-failure
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     pytest-aiohttp
     coverage
     codecov
-    importlib_metadata==4.13.0;python_version=="3.7"
+    py37: importlib_metadata==4.13.0
 changedir = {homedir}/tmp
 commands =
     /usr/bin/git clone https://github.com/mitre/caldera.git --recursive {homedir}/tmp

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ deps =
     pytest-aiohttp
     coverage
     codecov
-    py37: importlib_metadata==4.13.0
 changedir = {homedir}/tmp
 commands =
     /usr/bin/git clone https://github.com/mitre/caldera.git --recursive {homedir}/tmp
@@ -37,7 +36,9 @@ allowlist_externals =
     /usr/bin/cp *
 
 [testenv:style]
-deps = pre-commit
+deps =
+    pre-commit
+    py37: importlib_metadata==4.13.0
 skip_install = true
 changedir={toxinidir}
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ deps =
     pytest-aiohttp
     coverage
     codecov
+    importlib-metadata < 5; python_version < "3.8"  # fix for https://github.com/PyCQA/bandit/issues/951
 changedir = {homedir}/tmp
 commands =
     /usr/bin/git clone https://github.com/mitre/caldera.git --recursive {homedir}/tmp
@@ -38,7 +39,7 @@ allowlist_externals =
 [testenv:style]
 deps =
     pre-commit
-    importlib-metadata==4.8.1; python_version == '3.7'
+    importlib-metadata < 5; python_version < "3.8"  # fix for https://github.com/PyCQA/bandit/issues/951
 changedir={toxinidir}
 commands =
     pre-commit run --all-files --show-diff-on-failure

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ deps =
     pytest-aiohttp
     coverage
     codecov
+    importlib_metadata==4.13.0;python_version=="3.7"
 changedir = {homedir}/tmp
 commands =
     /usr/bin/git clone https://github.com/mitre/caldera.git --recursive {homedir}/tmp

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ deps =
     importlib-metadata < 5; python_version < "3.8"  # fix for https://github.com/PyCQA/bandit/issues/951
 changedir={toxinidir}
 commands =
+    python -m pip freeze
     pre-commit run --all-files --show-diff-on-failure
 
 [testenv:coverage]


### PR DESCRIPTION
## Description

Due to https://github.com/PyCQA/bandit/issues/951, the `bandit` pre-commit hook errors out and fails the pipeline on Python 3.7. Since `pre-commit` creates its own `venv` to run hooks, we need to pin the `importlib-metadata` package as an additional dependency until `bandit` pins it at their level. Once resolved, we should remove the dependency pin from the pre-commit config.

This PR also updates the pre-commit hooks to their latest versions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified locally and in CI pipeline.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
