### PR TITLE
fix tox.ini issues and flake8 link

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-    - repo: https://gitlab.com/pycqa/flake8
+    - repo: https://github.com/pycqa/flake8
       rev: 5.0.4
       hooks:
           - id: flake8

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,6 @@ commands =
     python -m pip install -r /tmp/caldera/plugins/emu/requirements.txt
     coverage run -p -m pytest --tb=short --rootdir=/tmp/caldera /tmp/caldera/plugins/emu/tests -W ignore::DeprecationWarning
 allowlist_externals =
-    /usr/bin/sudo
     /usr/bin/git
     /usr/bin/cp
     /bin/rm

--- a/tox.ini
+++ b/tox.ini
@@ -22,14 +22,14 @@ deps =
     pytest-aiohttp
     coverage
     codecov
-changedir = {homedir}/tmp
+changedir = /tmp/caldera
 commands =
-    /usr/bin/git clone https://github.com/mitre/caldera.git --recursive {homedir}/tmp
-    /bin/rm -rf {homedir}/tmp/plugins/emu
-    python -m pip install -r {homedir}/tmp/requirements.txt
-    /usr/bin/cp -R {toxinidir} {homedir}/tmp/plugins/emu
-    python -m pip install -r {homedir}/tmp/plugins/emu/requirements.txt
-    coverage run -p -m pytest --tb=short --rootdir={homedir}/tmp {homedir}/tmp/plugins/emu/tests -W ignore::DeprecationWarning
+    /usr/bin/git clone https://github.com/mitre/caldera.git --recursive /tmp/caldera
+    /bin/rm -rf /tmp/caldera/plugins/emu
+    python -m pip install -r /tmp/caldera/requirements.txt
+    /usr/bin/cp -R {toxinidir} /tmp/caldera/plugins/emu
+    python -m pip install -r /tmp/caldera/plugins/emu/requirements.txt
+    coverage run -p -m pytest --tb=short --rootdir=/tmp/caldera /tmp/caldera/plugins/emu/tests -W ignore::DeprecationWarning
 allowlist_externals =
     /usr/bin/sudo
     /usr/bin/git
@@ -48,7 +48,7 @@ commands =
 deps =
     coverage
 skip_install = true
-changedir = {homedir}/tmp
+changedir = /tmp/caldera
 commands =
     coverage combine
     coverage html
@@ -59,7 +59,7 @@ deps =
     coveralls
     coverage
 skip_install = true
-changedir = {homedir}/tmp
+changedir = /tmp/caldera
 commands =
     coverage combine
     coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ allowlist_externals =
     /usr/bin/sudo
     /usr/bin/git
     /usr/bin/cp
+    /bin/rm
 
 [testenv:style]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,9 @@ commands =
     python -m pip install -r {homedir}/tmp/plugins/emu/requirements.txt
     coverage run -p -m pytest --tb=short --rootdir={homedir}/tmp {homedir}/tmp/plugins/emu/tests -W ignore::DeprecationWarning
 allowlist_externals =
-    /usr/bin/sudo *
-    /usr/bin/git *
-    /usr/bin/cp *
+    /usr/bin/sudo
+    /usr/bin/git
+    /usr/bin/cp
 
 [testenv:style]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ skip_missing_interpreters = true
 
 [testenv]
 description = run tests
-passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
+passenv = TOXENV,CI,TRAVIS,TRAVIS_*,CODECOV_*
 deps =
     virtualenv!=20.0.22
     pre-commit


### PR DESCRIPTION
## Description
- Apparently tox was updated so that you can no longer have spaces in `passenv`, as [some users have noted](https://github.com/tox-dev/tox/issues/2615). One workaround is to use commas instead.
- Flake8 link was switched from gitlab to [github](https://github.com/PyCQA/flake8).  
- Fixing `allowlist_externals` in tox.ini to allow tests to run
- Fixing directories for test commands

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
