### PR TITLE
[VIRTS-4593] Fix payload downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the decryption which requires installation of some dependencies. Depending on th
 can be installed using the following:
 
 - Ubuntu: `apt-get install zlib1g`
-- MacOS: `homebrew install zlib`
+- MacOS: `brew install zlib`
 - All OS's: `pip3 install -r requirements.txt`
 
 See URL for more information regarding `pyminizip`: https://github.com/smihica/pyminizip

--- a/app/emu_svc.py
+++ b/app/emu_svc.py
@@ -270,6 +270,8 @@ class EmuService(BaseService):
         for payload in self.required_payloads:
             copied = False
             found = False
+            if os.path.exists(os.path.join(self.payloads_dir, payload)):
+                continue
             for path in Path(self.repo_dir).rglob(payload):
                 found = True
                 target_path = os.path.join(self.payloads_dir, path.name)

--- a/download_payloads.sh
+++ b/download_payloads.sh
@@ -1,7 +1,7 @@
 # We are not able to bundle some payloads because their licensing
 # prohibits redistribution (notably sysinternals).  This script will
 # will download non-redistributable payloads.  If you're deploying
-# the plugin without interent access, you can copy this script to
+# the plugin without internet access, you can copy this script to
 # an internet connected host, run it, and then copy the resulting
 # payloads back to the emu/payloads directory
 

--- a/download_payloads.sh
+++ b/download_payloads.sh
@@ -32,3 +32,8 @@ unzip payloads/wce_v1_41beta_universal.zip -d payloads/
 curl -o payloads/wmiexec.vbs https://raw.githubusercontent.com/Twi1ight/AD-Pentest-Script/master/wmiexec.vbs
 
 curl -o payloads/psexec_sandworm.py https://raw.githubusercontent.com/SecureAuthCorp/impacket/c328de825265df12ced44d14b36c688cd9973f5c/examples/psexec.py
+
+if [ -f "data/adversary-emulation-plans/oilrig/Resources/Binaries/binaries.zip" ]
+then
+  unzip -P malware data/adversary-emulation-plans/oilrig/Resources/Binaries/binaries.zip
+fi

--- a/download_payloads.sh
+++ b/download_payloads.sh
@@ -32,8 +32,3 @@ unzip payloads/wce_v1_41beta_universal.zip -d payloads/
 curl -o payloads/wmiexec.vbs https://raw.githubusercontent.com/Twi1ight/AD-Pentest-Script/master/wmiexec.vbs
 
 curl -o payloads/psexec_sandworm.py https://raw.githubusercontent.com/SecureAuthCorp/impacket/c328de825265df12ced44d14b36c688cd9973f5c/examples/psexec.py
-
-if [ -f "data/adversary-emulation-plans/oilrig/Resources/Binaries/binaries.zip" ]
-then
-  unzip -P malware data/adversary-emulation-plans/oilrig/Resources/Binaries/binaries.zip
-fi


### PR DESCRIPTION
## Description

For some of the `adversary-emulation-plans` abilities, payloads were missing, or threw errors for not being copied:
- Some payloads were already present in `emu/payloads`, so a check has been added to `emu_svc.py` to prevent errors from being logged for those files
- `adversary-emulation-plans/oilrig` is responsible for most of the missing payloads. It is missing a `resources/utilities/crypt_executables.py` file - I [created a PR with the fix](https://github.com/center-for-threat-informed-defense/adversary_emulation_library/pull/138) on the `adversary_emulation_library` repo for this. All but one of the required payloads for that emulation plan are contained in the password protected zip file. The remaining payload, a renamed version of Mimikatz x64 (`m64.exe`) is missing, but instructions are present in the emulation plan for installing that manually.
- The remaining errors are for `netsess.exe` and `wce.exe`, both of which are downloaded by `download_payloads.sh`. I could not recreate these errors on my personal machine, as I was able to successfully pull and unzip both. I think that users may need to check if they have any security rules blocking those downloads.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Verified that server w/ emu started without error on linux and MacOS; the only errors are for oilrig payloads.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
