### PR TITLE
Evals forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ Using the Emu plugin with Caldera will enable users to access the adversary prof
 To run Caldera along with the Emu plugin:
 1. Download Caldera as detailed in the [Installation Guide](https://github.com/mitre/Caldera)
 2. Enable the Emu plugin by adding `- emu` to the list of enabled plugins in `conf/local.yml` or `conf/default.yml` (if running Caldera in insecure mode)
-3. On startup, Caldera will automatically download the Adversary Emulation Library to the `data` folder of the Emu plugin. You will see the Emu plugin shown on the left sidebar of the Caldera server, and you will be able to access the Adversary Emulation Library adversary profiles from the Adversary tab of the Caldera server.
+3. Start Caldera to automatically download the Adversary Emulation Library to the `data` folder of the Emu plugin. 
+4. Stop Caldera. 
+5. Some adversaries may require additional payloads and executables to be downloaded. Run the `download_payloads.sh` script to download these binaries to the `payloads` directory.
+6. Start Caldera again. You will see the Emu plugin shown on the left sidebar of the Caldera server, and you will be able to access the Adversary Emulation Library adversary profiles from the Adversary tab of the Caldera server.
 
 # Additional setup
 Each emulation plan will have an adversary and a set of facts. Please ensure to select the related facts to the 
-adversary when starting an operation. Some adversaries may require additional payloads and executables to be 
-downloaded. Run the `download_payloads.sh` script to download these binaries to the `payloads` directory.
+adversary when starting an operation. 
 
 Because some payloads within the Adversary Emulation Library are encrypted, a Python script is used to automate
 the decryption which requires installation of some dependencies. Depending on the host OS, `pyminizip`

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# CALDERA plugin: Emu
+# Caldera plugin: Emu
 
-A plugin supplying CALDERA with TTPs from the Center for Threat Informed Defense (CTID) Adversary Emulation Plans.
+A plugin supplying Caldera with TTPs from the Center for Threat Informed Defense (CTID) Adversary Emulation Plans.
 
 # Installation
 
-Using the Emu plugin with CALDERA will enable users to access the adversary profiles contained in the [CTID Adversary Emulation Library](https://github.com/center-for-threat-informed-defense/adversary_emulation_library). 
+Using the Emu plugin with Caldera will enable users to access the adversary profiles contained in the [CTID Adversary Emulation Library](https://github.com/center-for-threat-informed-defense/adversary_emulation_library). 
 
-To run CALDERA along with the Emu plugin:
-1. Download CALDERA as detailed in the [Installation Guide](https://github.com/mitre/caldera)
-2. Enable the Emu plugin by adding `- emu` to the list of enabled plugins in `conf/local.yml` or `conf/default.yml` (if running CALDERA in insecure mode)
-3. On startup, CALDERA will automatically download the Adversary Emulation Library to the `data` folder of the Emu plugin. You will see the Emu plugin shown on the left sidebar of the CALDERA server, and you will be able to access the Adversary Emulation Library adversary profiles from the Adversary tab of the CALDERA server.
+To run Caldera along with the Emu plugin:
+1. Download Caldera as detailed in the [Installation Guide](https://github.com/mitre/Caldera)
+2. Enable the Emu plugin by adding `- emu` to the list of enabled plugins in `conf/local.yml` or `conf/default.yml` (if running Caldera in insecure mode)
+3. On startup, Caldera will automatically download the Adversary Emulation Library to the `data` folder of the Emu plugin. You will see the Emu plugin shown on the left sidebar of the Caldera server, and you will be able to access the Adversary Emulation Library adversary profiles from the Adversary tab of the Caldera server.
 
 # Additional setup
 Each emulation plan will have an adversary and a set of facts. Please ensure to select the related facts to the 

--- a/app/emu_svc.py
+++ b/app/emu_svc.py
@@ -28,6 +28,7 @@ class EmuService(BaseService):
         self.evals_c2_host = self.get_config(name='emu', prop='evals_c2_host')
         self.evals_c2_port = self.get_config(name='emu', prop='evals_c2_port')
         self.app_svc = self.get_service('app_svc')
+        self.contact_svc = self.get_service('contact_svc')
         if not self.app_svc:
             self.log.error('App svc not found.')
         else:

--- a/app/emu_svc.py
+++ b/app/emu_svc.py
@@ -1,7 +1,9 @@
 import glob
+import json
 import os
 import uuid
 import yaml
+from aiohttp import web
 from pathlib import Path
 import shutil
 from subprocess import DEVNULL, PIPE, STDOUT, check_call, Popen, CalledProcessError
@@ -25,6 +27,38 @@ class EmuService(BaseService):
         BaseWorld.apply_config('emu', BaseWorld.strip_yml(self._emu_config_path)[0])
         self.evals_c2_host = self.get_config(name='emu', prop='evals_c2_host')
         self.evals_c2_port = self.get_config(name='emu', prop='evals_c2_port')
+        self.app_svc = self.get_service('app_svc')
+        if not self.app_svc:
+            self.log.error('App svc not found.')
+        else:
+            self.app_svc.application.router.add_route('POST', '/plugins/emu/beacons', self.handle_forwarded_beacon)
+
+    async def handle_forwarded_beacon(self, request):
+        try:
+            forwarded_profile = json.loads(await request.read())
+            profile = dict()
+            profile['paw'] = forwarded_profile.get('guid')
+            profile['contact'] = 'http'
+            profile['group'] = 'evals'
+            if 'platform' in forwarded_profile:
+                profile['platform'] = forwarded_profile.get('platform')
+            else:
+                profile['platform'] = 'evals'
+            if 'hostName' in forwarded_profile:
+                profile['host'] = forwarded_profile.get('hostName')
+            if 'user' in forwarded_profile:
+                profile['username'] = forwarded_profile.get('user')
+            if 'pid' in forwarded_profile:
+                profile['pid'] = forwarded_profile.get('pid')
+            if 'ppid' in forwarded_profile:
+                profile['ppid'] = forwarded_profile.get('ppid')
+            await self.contact_svc.handle_heartbeat(**profile)
+            response = 'Successfully processed forwarded beacon with session ID %s' % profile['paw']
+            return web.Response(text=response)
+        except Exception as e:
+            error_msg = 'Server error when processing forwarded beacon: %s' % e
+            self.log.error(error_msg)
+            raise web.HTTPBadRequest(error_msg)
 
     async def clone_repo(self, repo_url=None):
         """

--- a/download_payloads.sh
+++ b/download_payloads.sh
@@ -32,3 +32,14 @@ unzip payloads/wce_v1_41beta_universal.zip -d payloads/
 curl -o payloads/wmiexec.vbs https://raw.githubusercontent.com/Twi1ight/AD-Pentest-Script/master/wmiexec.vbs
 
 curl -o payloads/psexec_sandworm.py https://raw.githubusercontent.com/SecureAuthCorp/impacket/c328de825265df12ced44d14b36c688cd9973f5c/examples/psexec.py
+
+curl -o payloads/PSTools.zip https://web.archive.org/web/20221102141531/http://download.sysinternals.com/files/PSTools.zip
+unzip payloads/PSTools.zip -d payloads/PSTools
+psexec_md5=$(md5sum payloads/PSTools/PsExec64.exe | awk '{ print $1 }')
+if [ "$psexec_md5" = "84858ca42dc54947eea910e8fab5f668" ]
+then
+    cp payloads/PSTools/PsExec64.exe data/adversary-emulation-plans/turla/Resources/payloads/snake/PsExec.exe
+    echo "PsExec64.exe v2.4 copied to Turla payloads directory"
+else
+    echo "PsExec from PSTools.zip with MD5 '$psexec_md5' does not match v2.4 with MD5 of 84858ca42dc54947eea910e8fab5f668"
+fi

--- a/download_payloads.sh
+++ b/download_payloads.sh
@@ -43,3 +43,11 @@ then
 else
     echo "PsExec from PSTools.zip with MD5 '$psexec_md5' does not match v2.4 with MD5 of 84858ca42dc54947eea910e8fab5f668"
 fi
+
+curl -o payloads/pscp.exe https://the.earth.li/~sgtatham/putty/latest/w64/pscp.exe
+cp payloads/pscp.exe data/adversary-emulation-plans/turla/Resources/payloads/carbon/pscp.exe
+echo "Pscp.exe copied to Turla payloads directory"
+
+curl -o payloads/plink.exe https://the.earth.li/~sgtatham/putty/latest/w64/plink.exe
+cp payloads/plink.exe data/adversary-emulation-plans/turla/Resources/payloads/carbon/plink.exe
+echo "Plink.exe copied to Turla payloads directory"

--- a/download_payloads.sh
+++ b/download_payloads.sh
@@ -38,16 +38,19 @@ unzip payloads/PSTools.zip -d payloads/PSTools
 psexec_md5=$(md5sum payloads/PSTools/PsExec64.exe | awk '{ print $1 }')
 if [ "$psexec_md5" = "84858ca42dc54947eea910e8fab5f668" ]
 then
-    cp payloads/PSTools/PsExec64.exe data/adversary-emulation-plans/turla/Resources/payloads/snake/PsExec.exe
+    target_dir="data/adversary-emulation-plans/turla/Resources/payloads/snake"
+    mkdir -p "$target_dir" && cp payloads/PSTools/PsExec64.exe $target_dir/PsExec.exe
     echo "PsExec64.exe v2.4 copied to Turla payloads directory"
 else
     echo "PsExec from PSTools.zip with MD5 '$psexec_md5' does not match v2.4 with MD5 of 84858ca42dc54947eea910e8fab5f668"
 fi
 
 curl -o payloads/pscp.exe https://the.earth.li/~sgtatham/putty/latest/w64/pscp.exe
-cp payloads/pscp.exe data/adversary-emulation-plans/turla/Resources/payloads/carbon/pscp.exe
+target_dir="data/adversary-emulation-plans/turla/Resources/payloads/carbon"
+mkdir -p "$target_dir" && cp payloads/pscp.exe $target_dir/pscp.exe
 echo "Pscp.exe copied to Turla payloads directory"
 
 curl -o payloads/plink.exe https://the.earth.li/~sgtatham/putty/latest/w64/plink.exe
-cp payloads/plink.exe data/adversary-emulation-plans/turla/Resources/payloads/carbon/plink.exe
+target_dir="data/adversary-emulation-plans/turla/Resources/payloads/carbon"
+mkdir -p "$target_dir" && cp payloads/plink.exe $target_dir/plink.exe
 echo "Plink.exe copied to Turla payloads directory"


### PR DESCRIPTION
## Description

Add feature to enable Caldera to receive beacons from the Turla Carbon & Snake adversaries (which will be released soon by the CTID adversary emulation libraries as Caldera ports using the Emu plugin). This feature will be used in future ports to be released by ATT&CK Evals. The Evals C2 server will forward incoming implant beacons to Caldera, and these implants will then be tasked through the Caldera server. 
This branch also includes modifications to the download_payloads.sh script to download necessary resources for the Turla port.

@uruwhy and @mchan143 contributed to this PR 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran the entire Turla Carbon & Snake scenarios and verified that implant beacons were forwarded correctly to Caldera. Expected output was shown in the Evals C2 server and the new implants were shown as new agents in the Caldera Agents tab. Also, Caldera successfully tasked the implants via the Evals C2 server.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
