### PR TITLE
Requirement for live agent

### DIFF
--- a/app/requirements/check_registered.py
+++ b/app/requirements/check_registered.py
@@ -11,13 +11,9 @@ class Requirement(BaseRequirement):
         :param operation
         :return: True if it complies, False if it doesn't
         """
-        print("\n\n*********************\nin check_registered.py")
         agent_paws = [agent.paw for agent in await operation.active_agents()]
         for uf in link.used:
-            print("id: ", uf.value ,"   agent_paws:", agent_paws)
             if uf.value in agent_paws:
-                print("returning true - run this ability")
                 return True
-        print("returning false - don't run this ability")
         return False
     

--- a/app/requirements/check_registered.py
+++ b/app/requirements/check_registered.py
@@ -1,0 +1,23 @@
+from plugins.stockpile.app.requirements.base_requirement import BaseRequirement
+
+
+class Requirement(BaseRequirement):
+
+    async def enforce(self, link, operation):
+        """
+        Given a link and the current operation, ensure will only run if the agent with the given ID/PAW is alive.
+        
+        :param link
+        :param operation
+        :return: True if it complies, False if it doesn't
+        """
+        print("\n\n*********************\nin check_registered.py")
+        agent_paws = [agent.paw for agent in await operation.active_agents()]
+        for uf in link.used:
+            print("id: ", uf.value ,"   agent_paws:", agent_paws)
+            if uf.value in agent_paws:
+                print("returning true - run this ability")
+                return True
+        print("returning false - don't run this ability")
+        return False
+    


### PR DESCRIPTION
## Description

This PR provides a new requirement to only run an ability if the agent paw referenced in the ability matches a currently live agent. 
This feature was developed to enable the Turla port to only run an ability if the implant that will be tasked in that ability is actively beaconing in to the server. 

## Type of change


- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested on both the `Turla (Snake)` & `Turla (Carbon)` adversaries. Observed abilities running if the required implant/agent was listed as a live agents, and not running if it was not listed as a live agent.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


