### PR TITLE
Update tested python versions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,12 +9,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.7
-            toxenv: py37,style,coverage-ci
           - python-version: 3.8
             toxenv: py38,style,coverage-ci
           - python-version: 3.9
             toxenv: py39,style,coverage-ci
+          - python-version: 3.10.9
+            toxenv: py310,style,coverage-ci
+          - python-version: 3.11
+            toxenv: py311,style,coverage-ci
 
     steps:
       - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 skipsdist = True
 envlist =
-    py{37,38,39}
+    py{38,39,310,311}
     style
     coverage
     bandit


### PR DESCRIPTION
## Description

Caldera no longer supports Python 3.7, and we should test 3.10 and 3.11 now.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Check the output of the github workflow.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
