### PR TITLE
Update download_payloads.sh

### DIFF
--- a/download_payloads.sh
+++ b/download_payloads.sh
@@ -6,7 +6,7 @@
 # payloads back to the emu/payloads directory
 
 curl -o payloads/AdFind.zip http://www.joeware.net/downloads/files/AdFind.zip
-unzip payloads/AdFind.zip -d payloads/ -P NotMalware
+unzip -P NotMalware payloads/AdFind.zip -d payloads/ 
 cp payloads/AdFind.exe payloads/adfind.exe
 
 curl -o payloads/dnscat2.ps1 https://raw.githubusercontent.com/lukebaggett/dnscat2-powershell/master/dnscat2.ps1

--- a/download_payloads.sh
+++ b/download_payloads.sh
@@ -6,7 +6,7 @@
 # payloads back to the emu/payloads directory
 
 curl -o payloads/AdFind.zip http://www.joeware.net/downloads/files/AdFind.zip
-unzip payloads/AdFind.zip -d payloads/
+unzip payloads/AdFind.zip -d payloads/ -P NotMalware
 cp payloads/AdFind.exe payloads/adfind.exe
 
 curl -o payloads/dnscat2.ps1 https://raw.githubusercontent.com/lukebaggett/dnscat2-powershell/master/dnscat2.ps1


### PR DESCRIPTION
A password has been added to the ADFind zip, I've added it to the command to unzip the file so it doesn't stall the install of payloads.

## Description

Amended the unzip command for ADFind

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Tested on a clean install of emu on Ubuntu 24.04

## Checklist:

- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
