### PR TITLE
Use the provided password when downloading AdFind

### DIFF
--- a/download_payloads.sh
+++ b/download_payloads.sh
@@ -6,7 +6,7 @@
 # payloads back to the emu/payloads directory
 
 curl -o payloads/AdFind.zip http://www.joeware.net/downloads/files/AdFind.zip
-unzip payloads/AdFind.zip -d payloads/
+unzip -P $(unzip -p payloads/AdFind.zip password.txt) payloads/AdFind.zip -d payloads/
 cp payloads/AdFind.exe payloads/adfind.exe
 
 curl -o payloads/dnscat2.ps1 https://raw.githubusercontent.com/lukebaggett/dnscat2-powershell/master/dnscat2.ps1


### PR DESCRIPTION
## Description

Based on information on the AdFind download page, the executable has been encrypted with the key contained in password.txt. Decrypt it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The download script now successfully downloads and extracts `AdFind.exe`, which did not work previously.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [DOES NOT APPLY] I have made corresponding changes to the documentation
- [DOES NOT APPLY] I have added tests that prove my fix is effective or that my feature works
