### PR TITLE
Updated download_payloads.sh with m64.exe

### DIFF
--- a/download_payloads.sh
+++ b/download_payloads.sh
@@ -54,3 +54,6 @@ curl -o payloads/plink.exe https://the.earth.li/~sgtatham/putty/latest/w64/plink
 target_dir="data/adversary-emulation-plans/turla/Resources/payloads/carbon"
 mkdir -p "$target_dir" && cp payloads/plink.exe $target_dir/plink.exe
 echo "Plink.exe copied to Turla payloads directory"
+
+curl -o payloads/m64.exe https://github.com/ParrotSec/mimikatz/blob/master/x64/mimikatz.exe
+echo "x64 mimikatz.exe copied to payloads directory as m64.exe"


### PR DESCRIPTION
Updated download_payloads.sh to download mimikatz.exe x64 and rename to m64.exe to fix emulation plan oilrig

## Description

Updated download_payloads.sh to download mimikatz.exe x64 and rename to m64.exe to fix emulation plan [oilrig](https://github.com/center-for-threat-informed-defense/adversary_emulation_library/tree/master/oilrig). Addresses parts of #44 

Error: 

```
2025-03-05 15:36:58 WARNING  Could not find payload m64.exe within                            emu_svc.py:320
                             plugins/emu/data/adversary-emulation-plans.
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

After downloading and renaming mimikatz binary to m64.exe, error no longer shows up during server boot:




## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
