### PR TITLE
fix: document CVE-2023-45853 in pyminizip dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
+# WARNING: pyminizip 0.2.6 is affected by CVE-2023-45853 (integer overflow
+# in bundled minizip/zlib code). No patched version is available as of 2026-03.
+# Consider replacing with an alternative zip library when one becomes available.
 pyminizip==0.2.6


### PR DESCRIPTION
## Summary
Document known vulnerability CVE-2023-45853 in pyminizip 0.2.6 dependency.

## CVE Details
- **CVE-2023-45853**: Integer overflow in minizip (bundled in pyminizip) via `zipOpenNewFileInZip4_64`
- **Affected**: pyminizip 0.2.6 (all versions)
- **Status**: No patched version available from upstream
- **Severity**: Critical (CVSS 9.8)

## Changes
- Added advisory comment to `requirements.txt` documenting the unpatched CVE
- No code changes (no fix available)

## Recommendation
Consider replacing `pyminizip` with an alternative zip library (e.g., `zipfile` stdlib, `pyzipper`, or `python-minizip-ng`) when feasible.

## Test plan
- [ ] Verify emu plugin still loads and functions